### PR TITLE
Add groupID to redirect URL if present in request

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ exports.registerRoute = function(hook_name, args, cb) {
 		}
 
 		if (req.query.padName) {
-			r += 'document.location.href="/p/' + req.query.padName + '";' + "\n";
+      var redirectUrl = '/p/';
+      if (req.query.groupID) {
+        redirectUrl += req.query.groupID + '$';
+      }
+      redirectUrl += req.query.padName
+			r += 'document.location.href="' + redirectUrl + '";' + "\n";
 		}
 
 		r += '</script>' + "\n";

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 exports.registerRoute = function(hook_name, args, cb) {
-    args.app.get("/auth_session", function(req, res) {
+		args.app.get("/auth_session", function(req, res) {
 		var r = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">' + "\n";
 
 		r += '<html>' + "\n";
@@ -14,11 +14,11 @@ exports.registerRoute = function(hook_name, args, cb) {
 		}
 
 		if (req.query.padName) {
-      var redirectUrl = '/p/';
-      if (req.query.groupID) {
-        redirectUrl += req.query.groupID + '$';
-      }
-      redirectUrl += req.query.padName
+			var redirectUrl = '/p/';
+			if (req.query.groupID) {
+				redirectUrl += req.query.groupID + '$';
+			}
+			redirectUrl += req.query.padName
 			r += 'document.location.href="' + redirectUrl + '";' + "\n";
 		}
 
@@ -26,6 +26,6 @@ exports.registerRoute = function(hook_name, args, cb) {
 		r += '</body>' + "\n";
 		r += '</html>' + "\n";
 
-        res.send(r);
-    });
+				res.send(r);
+		});
 };


### PR DESCRIPTION
Some boards (boards which are tied to a specific group) need a groupID passed through as well.

This PR checks if the groupID is present in the URL, and if it is, passes it on to the redirect URL for etherpad to use.

I also noticed tabs and spaces were used. Converted it all to tabs (there seemed to be more tabs than spaces used).
