### PR TITLE
Fix freeze on startup with Etherpad 1.8.8 and later

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-exports.registerRoute = function(hook_name, args, cb) {
+exports.registerRoute = (hookName, args) => {
 	args.app.get("/auth_session", function(req, res) {
 		var r = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">' + "\n";
 


### PR DESCRIPTION
If the function has a callback argument, Etherpad expects the callback to be called.

Fixes #6.

cc @pankajchejara23
