### PR TITLE
pass pad settings as GET parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+var URL = require('url').URL;
+var settings = require('ep_etherpad-lite/node/utils/Settings');
+
 exports.registerRoute = (hookName, args) => {
 	args.app.get("/auth_session", function(req, res) {
 		var r = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">' + "\n";
@@ -25,6 +28,17 @@ exports.registerRoute = (hookName, args) => {
 			if (req.query.lang) {
 				redirectUrl += "?lang=" + encodeURIComponent(req.query.lang);
 			}
+
+            var urlHelper = new URL(
+                redirectUrl,
+                `${req.protocol}://${req.get("Host") || "example.org"}`
+            );
+            Object.keys(settings.padOptions).forEach(function(option) {
+                if (option in req.query) {
+                    urlHelper.searchParams.set(option, req.query[option]);
+                }
+            });
+            redirectUrl += urlHelper.search;
 
 			r += 'document.location.href="' + redirectUrl + '";' + "\n";
 		}


### PR DESCRIPTION
This code is based on the fork luniki/ep_auth-session, takes all possible padOptions and adds the set parameters to the redirection URL.