### PR TITLE
Allow etherpad to be hosted under a subdirectory

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ exports.registerRoute = (hookName, args) => {
     }
 
     if (req.query.padName) {
-      let redirectUrl = '/p/';
+      let redirectUrl = 'p/';
 
       if (req.query.groupID) {
         redirectUrl += encodeURIComponent(req.query.groupID) + '$';


### PR DESCRIPTION
I made this, change because I have etherpad under a subdirectory and this plugin would always redirect to the root directory. I have also tested it without a subdirectory and it worked as expected.