### PR TITLE
Fix bug with hasOwnProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,8 @@ exports.registerRoute = (hookName, args) => {
 
       redirectUrl += encodeURIComponent(req.query.padName);
 
-      const query = {};
-
       for (const queryKey in req.query) {
-        if (!req.query.hasOwnProperty(queryKey) || queryKey === "sessionID" || queryKey === "groupID" || queryKey === "padName") {
+        if (!Object.prototype.hasOwnProperty.call(req.query, queryKey) || queryKey === "sessionID" || queryKey === "groupID" || queryKey === "padName") {
           continue;
         }
         


### PR DESCRIPTION
Etherpad upgraded their version of express, [which uses `null` prototypes for various objects](https://github.com/expressjs/express/pull/4861). Because of this, `hasOwnProperty()` is not available on `re.query`. I therefore propose to use `Object.hasOwnProperty.call()` as a replacement.